### PR TITLE
Fix error after starting new file

### DIFF
--- a/operators/select/select.py
+++ b/operators/select/select.py
@@ -14,12 +14,12 @@ from ..utils.geometry import get_strip_corners
 
 from ..utils.draw import draw_line
 
-def draw_select(self, context):
+def draw_select(context, seconds, fadeout_duration):
     active_color = context.preferences.themes[0].sequence_editor.active_strip
     select_color = context.preferences.themes[0].sequence_editor.selected_strip
     outline_color = (0, 0, 0, 0.2)
 
-    opacity = 1 - (self.seconds / self.fadeout_duration)
+    opacity = 1 - (seconds / fadeout_duration)
 
     active_strip = context.scene.sequence_editor.active_strip
 
@@ -150,7 +150,7 @@ class PREV_OT_select(bpy.types.Operator):
                 for strip in strips:
                     strip.select = True
 
-        args = (self, context)
+        args = (context, self.seconds, self.fadeout_duration)
         self.handle_select = bpy.types.SpaceSequenceEditor.draw_handler_add(
             draw_select, args, 'PREVIEW', 'POST_PIXEL')
 


### PR DESCRIPTION
If you use the VSE when you open Blender, it may run fine  
but if you do `File >> New` then open a file or just go to the VSE, there will be an error spamming in the console, and you may not be able to use tools.  

What I believe is happening, is the `draw_select()` function is left running but is checking for properties in the now unregistered operator's `self.  
If this is the case then it would better to remove the actual function, rather than just bypass the error but this is the simpler solution.